### PR TITLE
Fix docker build - `apt-get install speedtest` failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM debian:bullseye
 RUN apt-get update && apt-get install -y curl jq gnupg1 apt-transport-https dirmngr
 
 # Install speedtest cli
-RUN curl -s https://install.speedtest.net/app/cli/install.deb.sh | bash
-RUN apt-get install speedtest
+RUN curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash
+RUN apt-get install -y speedtest
 
 COPY ./speedtest.sh .
 CMD ["./speedtest.sh"]


### PR DESCRIPTION
When building the image I am seeing problems trying to install the speedtest package. This is fixed by using the current installation command from the speedtest website:
- https://www.speedtest.net/apps/cli
- ``` RUN curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash RUN apt-get install -y speedtest ```

---

Build error log:

```shell
docker build -t robinmanuelthiel/speedtest:latest .
[+] Building 18.5s (9/10)                                                                                        docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 335B                                                                                             0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye                                                               1.5s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                    0.0s
 => [internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                  0.0s
 => CACHED [1/5] FROM docker.io/library/debian:bullseye@sha256:2c7a92a41cb814c00e7d455b2bc0c90ccdb9a4ced2ffdc10e562c7a84a186032  0.0s
 => [internal] load build context                                                                                                0.0s
 => => transferring context: 34B                                                                                                 0.0s
 => [2/5] RUN apt-get update && apt-get install -y curl jq gnupg1 apt-transport-https dirmngr                                    11.1s
 => [3/5] RUN curl -s https://install.speedtest.net/app/cli/install.deb.sh | bash                                                5.3s
 => ERROR [4/5] RUN apt-get install speedtest                                                                                    0.5s
------
 > [4/5] RUN apt-get install speedtest:
0.094 Reading package lists...
0.390 Building dependency tree...
0.458 Reading state information...
0.501 E: Unable to locate package speedtest
------
Dockerfile:8
--------------------
   6 |     # Install speedtest cli
   7 |     RUN curl -s https://install.speedtest.net/app/cli/install.deb.sh | bash
   8 | >>> RUN apt-get install speedtest
   9 |
  10 |     COPY ./speedtest.sh .
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get install speedtest" did not complete successfully: exit code: 100

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/tur2dm7wqi33zu9shh9s5zepd
```