### PR TITLE
Add support for server options (`-s` and `-o`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ Your ping is 6.223 ms.
 
 ## Configuration
 
-| Environment variable | Default value           | Description                       |
-| -------------------- | ----------------------- | --------------------------------- |
-| `LOOP`               | `false`                 | Run Speedtest in a loop           |
-| `LOOP_DELAY`         | `60`                    | Delay in seconds between the runs |
-| `DB_SAVE`            | `false`                 | Save values to InfluxDB           |
-| `DB_HOST`            | `http://localhost:8086` | InfluxDB Hostname                 |
-| `DB_NAME`            | `speedtest`             | InfluxDB Database name            |
-| `DB_USERNAME`        | `admin`                 | InfluxDB Username                 |
-| `DB_PASSWORD`        | `password`              | InfluxDB Password                 |
+| Environment variable  | Default value           | Description                                                                          |
+|-----------------------|-------------------------|--------------------------------------------------------------------------------------|
+| `LOOP`                | `false`                 | Run Speedtest in a loop                                                              |
+| `LOOP_DELAY`          | `60`                    | Delay in seconds between the runs                                                    |
+| `DB_SAVE`             | `false`                 | Save values to InfluxDB                                                              |
+| `DB_HOST`             | `http://localhost:8086` | InfluxDB Hostname                                                                    |
+| `DB_NAME`             | `speedtest`             | InfluxDB Database name                                                               |
+| `DB_USERNAME`         | `admin`                 | InfluxDB Username                                                                    |
+| `DB_PASSWORD`         | `password`              | InfluxDB Password                                                                    |
+| `SPEEDTEST_SERVER_ID` | none                    | Specify a server from the server list using its id                                   |
+| `SPEEDTEST_HOST`      | none                    | Specify a server, from the server list, using its host's fully qualified domain name |
 
 ## Grafana and InfluxDB
 


### PR DESCRIPTION
We want to be able to pass a server ID or fully qualified hostname to the speedtest CLI command so that we can use a specific server to test against, rather than the default server that the CLI selects for us.

This change adds two new mutually exclusive environment variables which can be used to specify either:
1. `SPEEDTEST_SERVER_ID` - A server from the server list using its id
2. `SPEEDTEST_HOSTNAME`  - A server, from the server list, using its host's fully qualified domain name

Impact on the speedtest CLI command:
1. If `SPEEDTEST_SERVER_ID` is specified, the `-s` option will be added

2. If `SPEEDTEST_HOSTNAME` is specified, the `-o` option will be added

3. If both environment variables are specified, the container will error out and not run the speedtest CLI command

4. If neither of the new environment variables are not present, the CLI command will be called as usual with the default server
   - `JSON=$(speedtest --accept-license --accept-gdpr -f json)`

5. If you specify an invalid server ID/host name you will see an error:
- `{"type":"log","timestamp":"2024-06-17T03:39:08Z","message":"Configuration - No servers defined (NoServersException)","level":"error"}`

---

To get the available ids, sponsors, and hostnames from speedtest run:
- `curl -s https://cli.speedtest.net/api/cli/config | jq -r '.servers[] | "id: \(.id), sponsor: \(.sponsor), host: \(.host)"'`

and you will get a response like:

```
id: 32298, sponsor: SYNLINQ, host: speedtest1.synlinq.de:8080
id: 44081, sponsor: 23M GmbH, host: speedtest.23m.com:8080
id: 53257, sponsor: LWLcom GmbH, host: netservice01.fra02.lwlcom.net:8080
id: 40094, sponsor: PVDataNet, host: speedtestde.pvdatanet.com:8080
id: 55462, sponsor: Twerion.net | Minecraft Server, host: speedtest.twerion.net:8080
id: 37492, sponsor: Melbicom, host: speedtest-fra.melbicom.net:8080
id: 10010, sponsor: fdcservers.net, host: lg-fra.fdcservers.net:8080
id: 54504, sponsor: Deutsche Glasfaser, host: speed2.dg-sys.net:8080
id: 46569, sponsor: wirsNET, host: speed1.wirsnet.com:8080
id: 23712, sponsor: kko.me | avrx.de, host: speedtest.kko.me:8080
```

Remove the port number from the entry and run the container with the new environment variable, for example:
- `docker run -e SPEEDTEST_SERVER_ID=32298 robinmanuelthiel/speedtest:latest`
- `docker run -e SPEEDTEST_HOSTNAME=speedtest1.synlinq.de robinmanuelthiel/speedtest:latest`