### PR TITLE
Fix for `speedtest.sh` execution permissions issue in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/scr
 RUN apt-get install -y speedtest
 
 COPY ./speedtest.sh .
+RUN chmod +x ./speedtest.sh
 CMD ["./speedtest.sh"]


### PR DESCRIPTION
Hey @robinmanuelthiel  thanks for the wonderful Dockerfile project, it's really useful!

For non -nix based Docker hosts (I'm using Windows with WSL 2)
or that when the project is cloned, the ``speedtest.sh`  file tends not to carry the executable permission

hence I added a command to `chmod` it within the Docker container to make sure the executable permission is set within the Docker container / image

Thanks!

